### PR TITLE
Set a custom snapshots folder through env or arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14.x, 16.x]
+        node: [20.x, 22.x, 24.x, 25.x]
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Use node@${{ matrix.node }}
-        uses: actions/setup-node@v2
+        uses: actions/checkout@v4
+
+      - name: Setup node@${{ matrix.node }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
       - name: Install dependencies
         run: npm ci
+
       - name: Lint code
         run: npm run lint
+
       - name: Run tests
         run: npm run ci:test
+
       - name: Report code coverage
         uses: codecov/codecov-action@v2

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -56,6 +56,24 @@ describe("when nested", () => {
   });
 });
 
+it("takes a dir override from env", async () => {
+  process.env.SNAPSHOTS_PATH = path.join(__dirname, "override_snap_path_env");
+  await snap(JSON.stringify({ hello: "environment" }, null, 2), {
+    ext: ".json",
+  });
+  delete process.env.SNAPSHOTS_PATH;
+});
+
+it("takes a dir override from args", async () => {
+  process.argv.push(
+    "--snapshots_path",
+    path.join(__dirname, "override_snap_path_args")
+  );
+
+  await snap(JSON.stringify({ hello: "arguments" }, null, 2), { ext: ".json" });
+  process.argv.splice(-2);
+});
+
 it("takes an inline snapshot", async () => {
   await snap.inline(1, `1`);
   await snap.inline(

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -77,7 +77,10 @@ it("does not allow path traversal from env", async () => {
     });
     assert.fail("Should've thrown an error");
   } catch (err) {
-    assert.ok(err.message.includes("traversal"), "Expected a traversal error");
+    assert.ok(
+      (err as Error).message.includes("traversal"),
+      "Expected a traversal error"
+    );
   } finally {
     delete process.env.SNAPSHOTS_PATH;
   }
@@ -102,7 +105,10 @@ it("does not allow path traversal from args", async () => {
     });
     assert.fail("Should've thrown an error");
   } catch (err) {
-    assert.ok(err.message.includes("traversal"), "Expected a traversal error");
+    assert.ok(
+      (err as Error).message.includes("traversal"),
+      "Expected a traversal error"
+    );
   } finally {
     process.argv.splice(-2);
   }

--- a/src/__tests__/override_snap_path_args/__snapshots__/takes-a-dir-override-from-args.expected.json
+++ b/src/__tests__/override_snap_path_args/__snapshots__/takes-a-dir-override-from-args.expected.json
@@ -1,0 +1,3 @@
+{
+  "hello": "arguments"
+}

--- a/src/__tests__/override_snap_path_env/__snapshots__/takes-a-dir-override-from-env.expected.json
+++ b/src/__tests__/override_snap_path_env/__snapshots__/takes-a-dir-override-from-env.expected.json
@@ -1,0 +1,3 @@
+{
+  "hello": "environment"
+}

--- a/src/snap.ts
+++ b/src/snap.ts
@@ -4,7 +4,7 @@ import assert from "assert";
 import resolveFixture from "./util/resolve-fixture";
 import escapeFilename from "./util/escape-file-name";
 import store from "./util/store";
-import { getTest, getDir, getTitle } from "./util/cur-test";
+import { getTest, getDir, getTitle, getPath } from "./util/cur-test";
 import { cwd, update, snapDir } from "./constants";
 import { normalizeNL } from "./util/normalize-nl";
 
@@ -25,7 +25,7 @@ export default (expectError: boolean) => {
     const title = dir ? escapeFilename(curTest.title) : getTitle(curTest);
     const result = await resolveFixture(fixture);
     const indexes = store.indexes.get(store.curTest!)!;
-    const snapshotDir = path.join(dir || getDir(curTest), snapDir);
+    const snapshotDir = path.join(dir || getPath() || getDir(curTest), snapDir);
 
     if (ext && file) {
       throw new Error("Cannot specify both ext and file");

--- a/src/util/cur-test.ts
+++ b/src/util/cur-test.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { cwd } from "../constants";
 import store from "./store";
 import escapeFilename from "./escape-file-name";
+import { argv, env } from "process";
 
 export function getTest() {
   if (!store.curTest) {
@@ -12,6 +13,15 @@ export function getTest() {
   }
 
   return store.curTest;
+}
+
+export function getPath() {
+  const pathIndex = argv.indexOf("--snapshots_path");
+  const pathValue = pathIndex > -1 ? argv[pathIndex + 1] : undefined;
+
+  const snapPath = env.SNAPSHOTS_PATH || pathValue;
+
+  return typeof snapPath === "string" ? snapPath : undefined;
 }
 
 export function getDir(test: Mocha.Test) {

--- a/src/util/cur-test.ts
+++ b/src/util/cur-test.ts
@@ -27,28 +27,22 @@ export function getPath() {
 function retrievePathFromEnv() {
   const rawPath = env.SNAPSHOTS_PATH;
 
-  if (!rawPath) {
-    return undefined;
-  }
-
-  const absolutePath = path.resolve(rawPath);
-
-  if (!absolutePath.startsWith(cwd)) {
-    throw new Error("Potential path traversal");
-  }
-
-  return absolutePath;
+  return normalizePath(rawPath);
 }
 
 function retrievePathFromArguments() {
   const pathIndex = argv.indexOf("--snapshots_path");
   const pathValue = pathIndex > -1 ? argv[pathIndex + 1] : undefined;
 
-  if (!pathValue) {
+  return normalizePath(pathValue);
+}
+
+function normalizePath(rawPath: string | undefined) {
+  if (!rawPath) {
     return undefined;
   }
 
-  const absolutePath = path.resolve(pathValue);
+  const absolutePath = path.resolve(rawPath);
 
   if (!absolutePath.startsWith(cwd)) {
     throw new Error("Potential path traversal");

--- a/src/util/cur-test.ts
+++ b/src/util/cur-test.ts
@@ -19,9 +19,7 @@ export function getPath() {
   const envPath = retrievePathFromEnv();
   const argsPath = retrievePathFromArguments();
 
-  const snapPath = envPath || argsPath;
-
-  return typeof snapPath === "string" ? snapPath : undefined;
+  return envPath || argsPath;
 }
 
 function retrievePathFromEnv() {

--- a/src/util/cur-test.ts
+++ b/src/util/cur-test.ts
@@ -16,12 +16,45 @@ export function getTest() {
 }
 
 export function getPath() {
+  const envPath = retrievePathFromEnv();
+  const argsPath = retrievePathFromArguments();
+
+  const snapPath = envPath || argsPath;
+
+  return typeof snapPath === "string" ? snapPath : undefined;
+}
+
+function retrievePathFromEnv() {
+  const rawPath = env.SNAPSHOTS_PATH;
+
+  if (!rawPath) {
+    return undefined;
+  }
+
+  const absolutePath = path.resolve(rawPath);
+
+  if (!absolutePath.startsWith(cwd)) {
+    throw new Error("Potential path traversal");
+  }
+
+  return absolutePath;
+}
+
+function retrievePathFromArguments() {
   const pathIndex = argv.indexOf("--snapshots_path");
   const pathValue = pathIndex > -1 ? argv[pathIndex + 1] : undefined;
 
-  const snapPath = env.SNAPSHOTS_PATH || pathValue;
+  if (!pathValue) {
+    return undefined;
+  }
 
-  return typeof snapPath === "string" ? snapPath : undefined;
+  const absolutePath = path.resolve(pathValue);
+
+  if (!absolutePath.startsWith(cwd)) {
+    throw new Error("Potential path traversal");
+  }
+
+  return absolutePath;
 }
 
 export function getDir(test: Mocha.Test) {


### PR DESCRIPTION
Hello,

This PR partially closes #6. It adds the possibility to provide a custom snapshots folder through environment variable `SNAPSHOTS_PATH` or arguments via `--snapshots_path`. Besides, it updates `ci.yml`.

Btw, it might seem logical to put a part of new functionality into `constants.ts`. However, it won't work because of the racing problem (the constants are calculated way before tests can set any environment values, so the constants remain undefined). 